### PR TITLE
strip '-i' arg in sudoCommand for sudoTest (SOFTWARE-1721)

### DIFF
--- a/sources/server/src/gov/lbl/srm/server/Config.java
+++ b/sources/server/src/gov/lbl/srm/server/Config.java
@@ -720,7 +720,8 @@ public class Config {
 		TSRMUtil.startUpInfo("       however, local _ls_ will not invoke sudo");
 	    }
 	    //String sudoTest = "sudo -v -S";
-	    String sudoTest = _sudoCommand +" -v -S";
+            // sudo -i is incompatible with -v
+	    String sudoTest = _sudoCommand.replaceFirst(" -i$", "").replaceFirst(" -i ", " ") +" -v -S";
 	    if (!TPlatformUtil.execCmdValidationWithReturn(sudoTest)) {
 		TSRMUtil.startUpInfo("Failed to verify sudo command:"+sudoTest+" Exiting.");
 		//System.exit(1);


### PR DESCRIPTION
This is kind of a hack, but 'sudo -i' is supposed to be allowed, but the
sudo test command has '-v' (verify), which doesn't work with '-i' ...

Just using a hard coded 'sudo -v -S' would probably be fine (maybe even
better), but if, say, sudoCommand contained an alternate fully-qualified
path to a custom sudo, that would break.  Not sure if we care, but we'll
try to cover our bases anyway.
