### PR TITLE
improve log message for '_gumsHostDN' (SOFTWARE-809)

### DIFF
--- a/sources/server/src/gov/lbl/srm/server/Config.java
+++ b/sources/server/src/gov/lbl/srm/server/Config.java
@@ -778,7 +778,7 @@ public class Config {
 	} else {
 	    _gumsHostDN = hostDN;
 	}	
-	TSRMUtil.startUpInfo(".. gums host dn"+_gumsHostDN);
+	TSRMUtil.startUpInfo(".. bestman host dn for gums: " + _gumsHostDN);
 
 	try {
 	    if (doXACML) {


### PR DESCRIPTION
It was confusing that the 'gums host dn' referred not to the DN of the
gums server that bestman was talking to, but to the DN in the bestman
cert (according to BESTMAN_GUMSCERTPATH & BESTMAN_GUMSKEYPATH) used to
talk to gums.  Hopefully this is at least a slight improvement.
